### PR TITLE
Update T2V batch sampler for Wan2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ modelscope download Wan-AI/Wan2.2-T2V-A14B --local_dir ./Wan2.2-T2V-A14B
 
 This repository supports the `Wan2.2-T2V-A14B` Text-to-Video model and can simultaneously support video generation at 480P and 720P resolutions.
 
+The batch sampler (`generate_t2v.py`) defaults to reading the checkpoint from `/mnt/petrelfs/zoukai/model/Wan2.2-T2V-A14B` and saving results under `/mnt/petrelfs/zoukai/data/Wan2.2-T2V-A14B`.
+
+By default the sampler runs with `frame_num=81`, `sample_steps=40`, `sample_shift=12.0` and `sample_guide_scale=(3.0, 4.0)`. Override these values with `--frame_num`, `--sample_steps`, `--sample_shift` and `--sample_guide_scale` if needed.
+
 
 ##### (1) Without Prompt Extension
 

--- a/generate_t2v.py
+++ b/generate_t2v.py
@@ -3,22 +3,38 @@
 
 import argparse, logging, os, random, sys, warnings, torch, torch.distributed as dist
 from datetime import datetime
-from wan.configs import WAN_CONFIGS, SIZE_CONFIGS, MAX_AREA_CONFIGS, SUPPORTED_SIZES
-from wan.utils.utils import cache_video, str2bool
+from wan.configs import WAN_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES
+from wan.utils.utils import save_video, str2bool
 
 warnings.filterwarnings("ignore")
 
 EXAMPLE_PROMPT = {
-    "t2v-14B": {"prompt": "Two anthropomorphic cats ..."}
+    "t2v-A14B": {"prompt": "Two anthropomorphic cats ..."}
 }
+
+DEFAULT_CFG = WAN_CONFIGS["t2v-A14B"]
+DEFAULT_GUIDE_SCALE = list(DEFAULT_CFG.sample_guide_scale)
 
 def _validate_args(args):
     assert args.ckpt_dir, "Please specify --ckpt_dir"
-    assert args.task in WAN_CONFIGS and "t2v" in args.task, "Only T2V tasks supported"
-    if args.sample_steps is None:
-        args.sample_steps = 50
-    if args.frame_num is None:
-        args.frame_num = 81
+    assert args.task in WAN_CONFIGS and args.task.startswith("t2v"), "Only T2V tasks supported"
+    cfg = WAN_CONFIGS[args.task]
+    if args.task != "t2v-A14B":
+        if args.sample_steps == DEFAULT_CFG.sample_steps:
+            args.sample_steps = cfg.sample_steps
+        if args.frame_num == DEFAULT_CFG.frame_num:
+            args.frame_num = cfg.frame_num
+        if args.sample_shift == DEFAULT_CFG.sample_shift:
+            args.sample_shift = cfg.sample_shift
+        if args.sample_guide_scale == DEFAULT_GUIDE_SCALE:
+            args.sample_guide_scale = list(cfg.sample_guide_scale)
+    if isinstance(args.sample_guide_scale, list):
+        if len(args.sample_guide_scale) == 1:
+            args.sample_guide_scale = args.sample_guide_scale[0]
+        elif len(args.sample_guide_scale) == 2:
+            args.sample_guide_scale = tuple(args.sample_guide_scale)
+        else:
+            raise ValueError("--sample_guide_scale expects one or two floats")
     args.base_seed = args.base_seed if args.base_seed >= 0 else random.randint(0, sys.maxsize)
     assert args.size in SUPPORTED_SIZES[args.task], (
         f"{args.size} not supported, choose from {SUPPORTED_SIZES[args.task]}"
@@ -29,11 +45,11 @@ def _validate_args(args):
 
 def _parse_args():
     p = argparse.ArgumentParser("Wan T2V batch sampler")
-    p.add_argument("--task", default="t2v-14B", choices=[k for k in WAN_CONFIGS if "t2v" in k])
+    p.add_argument("--task", default="t2v-A14B", choices=[k for k in WAN_CONFIGS if k.startswith("t2v")])
     p.add_argument("--size", default="1280*720", choices=list(SIZE_CONFIGS.keys()))
-    p.add_argument("--frame_num", type=int, default=None)
-    p.add_argument("--ckpt_dir", required=True)
-    p.add_argument("--output_dir", required=True)
+    p.add_argument("--frame_num", type=int, default=DEFAULT_CFG.frame_num)
+    p.add_argument("--ckpt_dir", default="/mnt/petrelfs/zoukai/model/Wan2.2-T2V-A14B")
+    p.add_argument("--output_dir", default="/mnt/petrelfs/zoukai/data/Wan2.2-T2V-A14B")
     p.add_argument("--prompt_file_input", required=True, help="txt，每行一个生成 prompt")
     p.add_argument("--prompt_file_name", required=True, help="txt，每行一个命名 prompt")
     p.add_argument("--split", default="1/1")
@@ -45,9 +61,15 @@ def _parse_args():
     p.add_argument("--dit_fsdp", action="store_true")
     p.add_argument("--base_seed", type=int, default=-1)
     p.add_argument("--sample_solver", default="unipc", choices=["unipc","dpm++"])
-    p.add_argument("--sample_steps", type=int, default=None)
-    p.add_argument("--sample_shift", type=float, default=5.0)
-    p.add_argument("--sample_guide_scale", type=float, default=5.0)
+    p.add_argument("--sample_steps", type=int, default=DEFAULT_CFG.sample_steps)
+    p.add_argument("--sample_shift", type=float, default=DEFAULT_CFG.sample_shift)
+    p.add_argument(
+        "--sample_guide_scale",
+        type=float,
+        nargs="*",
+        default=DEFAULT_GUIDE_SCALE,
+        help="Classifier free guidance scale (one or two floats)",
+    )
     p.add_argument("--reverse", action="store_true", help="是否反向生成")
     args = p.parse_args()
     _validate_args(args)
@@ -153,7 +175,7 @@ def generate(args):
                 offload_model=args.offload_model,
             )
             if rank == 0:
-                cache_video(
+                save_video(
                     tensor=video[None],
                     save_file=outpath,
                     fps=cfg.sample_fps,
@@ -165,104 +187,17 @@ def generate(args):
 
 
 
-"""
+"""Example usage:
 srun -p video-aigc-3 --nodes=1 --gres=gpu:8 --cpus-per-task=16 \
-torchrun --nproc_per_node=8 --master_port=29525 generate_t2v.py \
---task t2v-14B \
---size 1280*720 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-14B \
---dit_fsdp --t5_fsdp --ulysses_size 8 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-14B_aug_seed42 \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx_seed42.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---sample_shift 5.0 \
---sample_guide_scale 5 \
---split 0/2 
-
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 --master_port=29505 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug_seed42 \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx_seed42.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---sample_shift 3.0 \
---sample_guide_scale 6 \
---split 1/2 
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 --master_port=29502 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug_seed42 \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx_seed42.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---sample_shift 3.0 \
---sample_guide_scale 6 \
---split 0/1 \
---reverse
-
-
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 --master_port=29525 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug_new \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx_new.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---sample_shift 3.0 \
---sample_guide_scale 6 \
---split 0/2 \
---reverse
-
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 --master_port=29503 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug_new \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx_new.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---sample_shift 3.0 \
---sample_guide_scale 6 \
---split 1/2 \
---reverse
-
-
-
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---split 0/2
-
-srun -p video-aigc-3 --nodes=1 --gres=gpu:4 --cpus-per-task=16 \
-torchrun --nproc_per_node=4 --master_port=29503 generate_t2v.py \
---task t2v-1.3B \
---size 832*480 \
---ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.1-T2V-1.3B \
---dit_fsdp --t5_fsdp --ulysses_size 4 \
---output_dir /mnt/petrelfs/zoukai/data/Wan2.1-T2V-1.3B_aug \
---prompt_file_input /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension_aug_wanx.txt \
---prompt_file_name  /mnt/petrelfs/zoukai/code/VBench/prompts/all_dimension.txt \
---split 1/2
-
+ torchrun --nproc_per_node=8 --master_port=29525 generate_t2v.py \
+ --task t2v-A14B \
+ --size 1280*720 \
+ --ckpt_dir /mnt/petrelfs/zoukai/model/Wan2.2-T2V-A14B \
+ --dit_fsdp --t5_fsdp --ulysses_size 8 \
+ --output_dir /mnt/petrelfs/zoukai/data/Wan2.2-T2V-A14B \
+ --prompt_file_input /path/to/prompts.txt \
+ --prompt_file_name  /path/to/names.txt \
+ --split 0/1
 """
 if __name__ == "__main__":
     generate(_parse_args())

--- a/wan/modules/s2v/model_s2v.py
+++ b/wan/modules/s2v/model_s2v.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 
 import numpy as np
 import torch
-import torch.cuda.amp as amp
 import torch.nn as nn
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.models.modeling_utils import ModelMixin
@@ -58,7 +57,7 @@ def torch_dfs(model: nn.Module, parent_name='root'):
     return modules, module_names
 
 
-@amp.autocast(enabled=False)
+@torch.amp.autocast('cuda', enabled=False)
 def rope_apply(x, grid_sizes, freqs, start=None):
     n, c = x.size(2), x.size(3) // 2
     # loop over samples
@@ -76,7 +75,7 @@ def rope_apply(x, grid_sizes, freqs, start=None):
     return torch.stack(output).float()
 
 
-@amp.autocast(enabled=False)
+@torch.amp.autocast('cuda', enabled=False)
 def rope_apply_usp(x, grid_sizes, freqs):
     s, n, c = x.size(1), x.size(2), x.size(3) // 2
     # loop over samples
@@ -141,7 +140,7 @@ class Head_S2V(Head):
             e(Tensor): Shape [B, L1, C]
         """
         assert e.dtype == torch.float32
-        with amp.autocast(dtype=torch.float32):
+        with torch.amp.autocast('cuda', dtype=torch.float32):
             e = (self.modulation + e.unsqueeze(1)).chunk(2, dim=1)
             x = (self.head(self.norm(x) * (1 + e[1]) + e[0]))
         return x
@@ -203,7 +202,7 @@ class WanS2VAttentionBlock(WanAttentionBlock):
         seg_idx = [0, seg_idx, x.size(1)]
         e = e[0]
         modulation = self.modulation.unsqueeze(2)
-        with amp.autocast(dtype=torch.float32):
+        with torch.amp.autocast('cuda', dtype=torch.float32):
             e = (modulation + e).chunk(6, dim=1)
         assert e[0].dtype == torch.float32
 
@@ -216,7 +215,7 @@ class WanS2VAttentionBlock(WanAttentionBlock):
         norm_x = torch.cat(parts, dim=1)
         # self-attention
         y = self.self_attn(norm_x, seq_lens, grid_sizes, freqs)
-        with amp.autocast(dtype=torch.float32):
+        with torch.amp.autocast('cuda', dtype=torch.float32):
             z = []
             for i in range(2):
                 z.append(y[:, seg_idx[i]:seg_idx[i + 1]] * e[2][:, i:i + 1])
@@ -232,7 +231,7 @@ class WanS2VAttentionBlock(WanAttentionBlock):
                              (1 + e[4][:, i:i + 1]) + e[3][:, i:i + 1])
             norm2_x = torch.cat(parts, dim=1)
             y = self.ffn(norm2_x)
-            with amp.autocast(dtype=torch.float32):
+            with torch.amp.autocast('cuda', dtype=torch.float32):
                 z = []
                 for i in range(2):
                     z.append(y[:, seg_idx[i]:seg_idx[i + 1]] * e[5][:, i:i + 1])
@@ -506,7 +505,7 @@ class WanModel_S2V(ModelMixin, ConfigMixin):
         if freqs.device != device:
             freqs = freqs.to(device)
         if self.trainable_token_pos_emb:
-            with amp.autocast(dtype=torch.float64):
+            with torch.amp.autocast('cuda', dtype=torch.float64):
                 token_freqs = self.token_freqs.to(torch.float64)
                 token_freqs = token_freqs / token_freqs.norm(
                     dim=-1, keepdim=True)
@@ -775,7 +774,7 @@ class WanModel_S2V(ModelMixin, ConfigMixin):
         # time embeddings
         if self.zero_timestep:
             t = torch.cat([t, torch.zeros([1], dtype=t.dtype, device=t.device)])
-        with amp.autocast(dtype=torch.float32):
+        with torch.amp.autocast('cuda', dtype=torch.float32):
             e = self.time_embedding(
                 sinusoidal_embedding_1d(self.freq_dim, t).float())
             e0 = self.time_projection(e).unflatten(1, (6, self.dim))


### PR DESCRIPTION
## Summary
- default batch sampler to Wan2.2-T2V-A14B checkpoint and output paths
- expose sampler defaults for frame count, steps, shift, and guidance; use `save_video`
- replace deprecated `torch.cuda.amp.autocast` with `torch.amp.autocast('cuda')` in S2V model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c01f5534a883288e7e7323337b8e29